### PR TITLE
For Estonian mobile numbers don't require the 372 prefix

### DIFF
--- a/app/src/main/java/ee/ria/EstEIDUtility/fragment/ContainerDetailsFragment.java
+++ b/app/src/main/java/ee/ria/EstEIDUtility/fragment/ContainerDetailsFragment.java
@@ -437,6 +437,16 @@ public class ContainerDetailsFragment extends Fragment implements AddedAdesSigna
                         preferences.updateMobileNumber(phone);
                         preferences.updatePersonalCode(pCode);
                     }
+                    final String estonianCountryCode = "372";
+                    final String plusPrefixedEstonianCountryCode = "+" + estonianCountryCode;
+                    final String firstNumberInEstonianMobileNumbers = "5";
+
+                    if (!phone.startsWith(estonianCountryCode) && !phone.startsWith(plusPrefixedEstonianCountryCode)) {
+                        if (phone.startsWith(firstNumberInEstonianMobileNumbers)) {
+                            phone = estonianCountryCode + phone;
+                        }
+                    }
+
                     String message = getResources().getString(R.string.action_sign) + " " + containerFacade.getName();
                     MobileCreateSignatureRequest request = CreateSignatureRequestBuilder
                             .aCreateSignatureRequest()

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -192,7 +192,7 @@
     <string name="unknown_error">Tundmatu viga Mobiil-ID\'ga allkirjastamisel</string>
     <string name="local_service_exception">Midagi läks valesti, proovi hiljem uuesti</string>
     <string name="general_client">Midagi läks valesti, proovi uuesti</string>
-    <string name="incorrect_input_parameters">Vigane telefoninumber ja/või isikukood, telefoninumber peab sisaldama riigikoodi</string>
+    <string name="incorrect_input_parameters">Vigane telefoninumber ja/või isikukood, välismaa telefoninumber peab algama riigikoodiga</string>
     <string name="missing_input_parameters">Puudub telefoninumber ja/või isikukood</string>
     <string name="ocsp_unauthorized">Mobiilse allkirjastamise teenusele ei õnnestu ligi pääseda</string>
     <string name="general_service">Viga DigidocService\'ga, proovi hiljem uuesti</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -192,7 +192,7 @@
     <string name="unknown_error">Unknown error occurred when signing with Mobile ID</string>
     <string name="local_service_exception">Something went wrong, try again later</string>
     <string name="general_client">Something went wrong, try again</string>
-    <string name="incorrect_input_parameters">Incorrect mobile number and/or personal code, mobile number must contain country code</string>
+    <string name="incorrect_input_parameters">Incorrect mobile number and/or personal code, non-Estonian mobile numbers must be prefixed with the country code</string>
     <string name="missing_input_parameters">Missing mobile number and/or personal code</string>
     <string name="ocsp_unauthorized">Unable to access mobile sign service</string>
     <string name="general_service">There was an error with Digidoc service, try again later</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,7 +192,7 @@
     <string name="unknown_error">Unknown error occurred when signing with Mobile ID</string>
     <string name="local_service_exception">Something went wrong, try again later</string>
     <string name="general_client">Something went wrong, try again</string>
-    <string name="incorrect_input_parameters">Incorrect mobile number and/or personal code, mobile number must contain country code</string>
+    <string name="incorrect_input_parameters">Incorrect mobile number and/or personal code, non-Estonian mobile numbers must be prefixed with the country code</string>
     <string name="missing_input_parameters">Missing mobile number and/or personal code</string>
     <string name="ocsp_unauthorized">Unable to access mobile signing service</string>
     <string name="general_service">There was an error with Digidoc service, try again later</string>


### PR DESCRIPTION
For Estonian mobile numbers don't require the 372 prefix
If the mobile number is not prefixed with 372 (Estonian country code) check if it's an Estonian cell and fill in the country code automatically