### PR TITLE
Allow the name and personal code on a signature to wrap to 2 lines

### DIFF
--- a/app/src/main/res/layout/fragment_container_signatures.xml
+++ b/app/src/main/res/layout/fragment_container_signatures.xml
@@ -45,7 +45,7 @@
         android:layout_marginTop="5dp"
         android:layout_toEndOf="@+id/signatureImage"
         android:layout_toStartOf="@+id/removeSignature"
-        android:maxLines="1"
+        android:maxLines="2"
         android:text="@android:string/unknownName"
         android:textAppearance="?android:attr/textAppearanceLarge" />
 


### PR DESCRIPTION
Currently in portrait view the personal code gets hidden (as it does not fit on screen) and can only
be seen in landscape